### PR TITLE
Silence the warning for functions with zero arguments

### DIFF
--- a/analyzer/languages/c/common/runtime.ml
+++ b/analyzer/languages/c/common/runtime.ml
@@ -291,11 +291,6 @@ let raise_ffi_shape_number_error range pp_term term man flow =
 let raise_ffi_arity_mismatch range ~expected ~actual man flow =
   let cs = Flow.get_callstack flow in
   let alarm = mk_alarm (A_ffi_arity_mismatch (expected, actual)) cs range in
-  if expected = 1 && actual = 0 then
-    (* probably the unit case, we only info about it *)
-    let diag = mk_info_diagnostic alarm in
-    Flow.add_diagnostic diag flow
-  else
     Flow.raise_alarm alarm ~bottom:true man.lattice flow
 
 let raise_ffi_void_return range man flow =

--- a/analyzer/languages/c/iterators/program.ml
+++ b/analyzer/languages/c/iterators/program.ml
@@ -253,7 +253,10 @@ struct
   let exec_arity_check f (ty: Type_shapes.fn_value_shapes) range man flow =
     let actual = List.length (f.c_func_parameters) in
     let expected = List.length (ty.arguments) in
-    if actual != expected && expected <= 5  then
+    if actual != expected && actual = 0 then
+      (* Taking zero arguments is fine. *)
+      Post.return flow
+    else if actual != expected && expected <= 5  then
       let flow = raise_ffi_arity_mismatch range ~actual ~expected man flow in
       Post.return flow
     else if expected > 5 && actual != 2 then


### PR DESCRIPTION
This PR silences the warning for FFI functions that have declared external arguments, but which do not take the corresponding arguments in the C implementation.